### PR TITLE
Deserialize in one go

### DIFF
--- a/src/scrapper.rs
+++ b/src/scrapper.rs
@@ -1,11 +1,22 @@
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 
 const URL_MAP: &str = "https://www.pollens.fr/load_vigilance_map";
 
 #[derive(serde::Deserialize, Debug)]
 struct Map {
-    #[serde(rename = "vigilanceMapCounties")]
-    vigilance_map_counties: String,
+    #[serde(rename = "vigilanceMapCounties", deserialize_with = "de_str_as_json")]
+    vigilance_map_counties: HashMap<u8, Departement>,
+}
+
+/// Désérialise une chaîne de caractère en tant que JSON
+fn de_str_as_json<'de, D: Deserializer<'de>, T: DeserializeOwned>(
+    deserializer: D,
+) -> Result<T, D::Error> {
+    use serde::de::Error;
+    let str = String::deserialize(deserializer)?;
+    serde_json::from_str(&str).map_err(D::Error::custom)
 }
 
 #[derive(serde::Deserialize, Debug)]
@@ -25,5 +36,5 @@ pub struct Risk {
 
 pub async fn scrap() -> HashMap<u8, Departement> {
     let reponse: Map = reqwest::get(URL_MAP).await.unwrap().json().await.unwrap();
-    serde_json::from_str(&reponse.vigilance_map_counties).unwrap()
+    reponse.vigilance_map_counties
 }

--- a/src/scrapper.rs
+++ b/src/scrapper.rs
@@ -15,8 +15,8 @@ fn de_str_as_json<'de, D: Deserializer<'de>, T: DeserializeOwned>(
     deserializer: D,
 ) -> Result<T, D::Error> {
     use serde::de::Error;
-    let str = String::deserialize(deserializer)?;
-    serde_json::from_str(&str).map_err(D::Error::custom)
+    let str = std::borrow::Cow::<str>::deserialize(deserializer)?;
+    serde_json::from_str(str.as_ref()).map_err(D::Error::custom)
 }
 
 #[derive(serde::Deserialize, Debug)]


### PR DESCRIPTION
On a une double désérialisation à faire. Plutôt que de le faire en deux étapes dans `scrap`, j'ai implémenté une fonction de désérialisation moi même qui fait la seconde déserialisation en même temps que la 1ère (L14). Ça donne l'impression de ne désérialiser qu'une fois.

Hésite pas à regarder le diff pour voir ce qui a changé, mais je répète que serde, en interne, est super complexe et que certaines choses peuvent avoir l'air un peu tordues.